### PR TITLE
Added missing English resource texts to other language files

### DIFF
--- a/resources/language/Dutch/strings.po
+++ b/resources/language/Dutch/strings.po
@@ -87,15 +87,15 @@ msgstr "Fout"
 
 msgctxt "#30022"
 msgid "Due to broadcast restrictions, NFL Game Pass Domestic is currently unavailable. Please try again later."
-msgstr "Vanwege uitzend beperkingen, NFL Game Pass Domestic is momenteel niet beschikbaar. Probeer het later opnieuw."
+msgstr "Vanwege uitzendbeperkingen is NFL Game Pass Domestic momenteel niet beschikbaar. Probeer het later opnieuw."
 
 msgctxt "#30023"
 msgid "Logging into NFL Game Pass failed. Make sure that your account information is correct and your subscription is valid."
-msgstr "Inloggen in NFL Game Pass mislukt. Zorg ervoor dat uw account informatie correct zijn en uw abonnement geldig is."
+msgstr "Inloggen bij NFL Game Pass is mislukt. Zorg ervoor dat uw accountgegevens correct zijn en uw abonnement geldig is."
 
 msgctxt "#30024"
 msgid "Unexpected error ='(. Please enable debuging for both the addon and Kodi, and submit a bug report."
-msgstr ""
+msgstr "Onverwachte fout ='(. Schakel debug logging in voor zowel de addon als Kodi en verstuur een bug report."
 
 msgctxt "#30025"
 msgid "Hide game length"
@@ -127,40 +127,60 @@ msgstr "Coaches Film"
 
 msgctxt "#30033"
 msgid "Proxy Settings"
-msgstr ""
+msgstr "Proxy Instellingen"
 
 msgctxt "#30034"
 msgid "Use an HTTP proxy to access Game Pass"
-msgstr ""
+msgstr "Gebruik een HTTP proxy om Game Pass te benaderen"
 
 msgctxt "#30035"
 msgid "Protocol"
-msgstr ""
+msgstr "Protocol"
 
 msgctxt "#30036"
 msgid "Server"
-msgstr ""
+msgstr "Server"
 
 msgctxt "#30037"
 msgid "Port"
-msgstr ""
+msgstr "Poort"
 
 msgctxt "#30038"
 msgid "Username"
-msgstr ""
+msgstr "Gebruikersnaam"
 
 msgctxt "#30039"
 msgid "Password"
-msgstr ""
+msgstr "Wachtwoord"
 
 msgctxt "#30042"
 msgid "Enable 'Basic' Authentication"
-msgstr ""
+msgstr "Gebruik 'Eenvoudige' Authenticatie"
 
 msgctxt "#30043"
 msgid "There was a problem playing that stream"
-msgstr ""
+msgstr "Er was een probleem bij het afspelen van de stream"
 
 msgctxt "#30044"
 msgid "Some shows are known to not work. Please file a bug if the show is available and works in the official app."
 msgstr ""
+
+msgctxt "#30045"
+msgid "No valid stream URL was found."
+msgstr "Geen geldige stream URL gevonden."
+
+msgctxt "#30046"
+msgid "There is currently no data available for this week."
+msgstr "Er zijn op dit moment geen gegevens beschikbaar voor deze week."
+
+msgctxt "#30047"
+msgid "PRESEASON WEEK {0}"
+msgstr "VOORSEIZOEN WEEK {0}"
+
+msgctxt "#30048"
+msgid "WEEK {0}"
+msgstr "WEEK {0}"
+
+msgctxt "#30049"
+msgid "Use InputStream Adaptive"
+msgstr "Gebruik Inputstream Adaptive"

--- a/resources/language/Dutch/strings.po
+++ b/resources/language/Dutch/strings.po
@@ -78,8 +78,8 @@ msgid "Choose a game version"
 msgstr "Kies een wedstrijd versie"
 
 msgctxt "#30020"
-msgid "Date/time in local time"
-msgstr "Datum/tijd in lokale tijd"
+msgid "Time Notation"
+msgstr "Tijd Weergave"
 
 msgctxt "#30021"
 msgid "Error"
@@ -106,12 +106,12 @@ msgid "No"
 msgstr "Nee"
 
 msgctxt "#30027"
-msgid "Yes, with 12-hour clock (AM/PM)"
-msgstr "Ja, met 12-uurs klok (AM/PM)"
+msgid "12-hour clock (AM/PM)"
+msgstr "12-uurs klok (AM/PM)"
 
 msgctxt "#30028"
-msgid "Yes, with 24-hour clock"
-msgstr "Ja, met 24-uurs klok"
+msgid "24-hour clock"
+msgstr "24-uurs klok"
 
 msgctxt "#30029"
 msgid "General"

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -78,8 +78,8 @@ msgid "Choose a game version"
 msgstr "Wähle eine Spiel Version"
 
 msgctxt "#30020"
-msgid "Date/time in local time"
-msgstr "Uhrzeit in lokaler Zeitzone"
+msgid "Time Notation"
+msgstr ""
 
 msgctxt "#30021"
 msgid "Error"
@@ -106,11 +106,11 @@ msgid "No"
 msgstr ""
 
 msgctxt "#30027"
-msgid "Yes, with 12-hour clock (AM/PM)"
+msgid "12-hour clock (AM/PM)"
 msgstr ""
 
 msgctxt "#30028"
-msgid "Yes, with 24-hour clock"
+msgid "24-hour clock"
 msgstr ""
 
 msgctxt "#30029"

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -164,3 +164,23 @@ msgstr ""
 msgctxt "#30044"
 msgid "Some shows are known to not work. Please file a bug if the show is available and works in the official app."
 msgstr ""
+
+msgctxt "#30045"
+msgid "No valid stream URL was found."
+msgstr ""
+
+msgctxt "#30046"
+msgid "There is currently no data available for this week."
+msgstr ""
+
+msgctxt "#30047"
+msgid "PRESEASON WEEK {0}"
+msgstr ""
+
+msgctxt "#30048"
+msgid "WEEK {0}"
+msgstr ""
+
+msgctxt "#30049"
+msgid "Use InputStream Adaptive"
+msgstr ""

--- a/resources/language/Japanese/strings.po
+++ b/resources/language/Japanese/strings.po
@@ -165,3 +165,23 @@ msgstr "再生に問題が発生しました"
 msgctxt "#30044"
 msgid "Some shows are known to not work. Please file a bug if the show is available and works in the official app."
 msgstr "再生できない試合があります。公式アプリで再生できる場合、バグをレポートしてください。"
+
+msgctxt "#30045"
+msgid "No valid stream URL was found."
+msgstr ""
+
+msgctxt "#30046"
+msgid "There is currently no data available for this week."
+msgstr ""
+
+msgctxt "#30047"
+msgid "PRESEASON WEEK {0}"
+msgstr ""
+
+msgctxt "#30048"
+msgid "WEEK {0}"
+msgstr ""
+
+msgctxt "#30049"
+msgid "Use InputStream Adaptive"
+msgstr ""

--- a/resources/language/Japanese/strings.po
+++ b/resources/language/Japanese/strings.po
@@ -79,8 +79,8 @@ msgid "Choose a game version"
 msgstr "再生バージョン選択"
 
 msgctxt "#30020"
-msgid "Localize Game Date/Time"
-msgstr "現地時間"
+msgid "Time Notation"
+msgstr ""
 
 msgctxt "#30021"
 msgid "Error"
@@ -107,12 +107,12 @@ msgid "No"
 msgstr "いいえ"
 
 msgctxt "#30027"
-msgid "Yes, with 12-hour clock (AM/PM)"
-msgstr "はい、12時間制 (AM/PM)"
+msgid "12-hour clock (AM/PM)"
+msgstr "12時間制 (AM/PM)"
 
 msgctxt "#30028"
-msgid "Yes, with 24-hour clock"
-msgstr "はい、24時間制"
+msgid "24-hour clock"
+msgstr "24時間制"
 
 msgctxt "#30029"
 msgid "General"

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -78,8 +78,8 @@ msgid "Choose a game version"
 msgstr "Выбирать вручную"
 
 msgctxt "#30020"
-msgid "Localize Game Date/Time"
-msgstr "Локализировать время игр"
+msgid "Time Notation"
+msgstr ""
 
 msgctxt "#30021"
 msgid "Error"
@@ -106,12 +106,12 @@ msgid "No"
 msgstr "Нет"
 
 msgctxt "#30027"
-msgid "Yes, with 12-hour clock (AM/PM)"
-msgstr "Да, 12ч (AM/PM)"
+msgid "12-hour clock (AM/PM)"
+msgstr "12ч (AM/PM)"
 
 msgctxt "#30028"
-msgid "Yes, with 24-hour clock"
-msgstr "Да, 24ч"
+msgid "24-hour clock"
+msgstr "24ч"
 
 msgctxt "#30029"
 msgid "General"

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -172,3 +172,19 @@ msgstr "Некоторые шоу могут не работать. Пожалу
 msgctxt "#30045"
 msgid "No valid stream URL was found."
 msgstr "Не возможно найти URL для потока."
+
+msgctxt "#30046"
+msgid "There is currently no data available for this week."
+msgstr ""
+
+msgctxt "#30047"
+msgid "PRESEASON WEEK {0}"
+msgstr ""
+
+msgctxt "#30048"
+msgid "WEEK {0}"
+msgstr ""
+
+msgctxt "#30049"
+msgid "Use InputStream Adaptive"
+msgstr ""

--- a/resources/language/Ukrainian/strings.po
+++ b/resources/language/Ukrainian/strings.po
@@ -172,3 +172,19 @@ msgstr "Деякі шоу можуть не працювати. Будь лас�
 msgctxt "#30045"
 msgid "No valid stream URL was found."
 msgstr "Неможливо знайти URL для потоку."
+
+msgctxt "#30046"
+msgid "There is currently no data available for this week."
+msgstr ""
+
+msgctxt "#30047"
+msgid "PRESEASON WEEK {0}"
+msgstr ""
+
+msgctxt "#30048"
+msgid "WEEK {0}"
+msgstr ""
+
+msgctxt "#30049"
+msgid "Use InputStream Adaptive"
+msgstr ""

--- a/resources/language/Ukrainian/strings.po
+++ b/resources/language/Ukrainian/strings.po
@@ -78,8 +78,8 @@ msgid "Choose a game version"
 msgstr "Вибирати версію гри"
 
 msgctxt "#30020"
-msgid "Localize Game Date/Time"
-msgstr "Локалізувати час гри"
+msgid "Time Notation"
+msgstr ""
 
 msgctxt "#30021"
 msgid "Error"
@@ -106,12 +106,12 @@ msgid "No"
 msgstr "Ні"
 
 msgctxt "#30027"
-msgid "Yes, with 12-hour clock (AM/PM)"
-msgstr "Так, 12г (AM/PM)"
+msgid "12-hour clock (AM/PM)"
+msgstr "12г (AM/PM)"
 
 msgctxt "#30028"
-msgid "Yes, with 24-hour clock"
-msgstr "Так, 24г"
+msgid "24-hour clock"
+msgstr "24г"
 
 msgctxt "#30029"
 msgid "General"


### PR DESCRIPTION
I added the new language texts in the English strings.po to the other languages. And I improved / expanded the Dutch translation as well.

Not a game changer (ha ha), but one has to start small right. I didn't discuss this PR beforehand but I think I can't really go wrong with something as basic as this. 