### PR TITLE
Gameinfo - mask FINAL_OVERTIME as FINAL

### DIFF
--- a/default.py
+++ b/default.py
@@ -170,6 +170,8 @@ class GamepassGUI(xbmcgui.WindowXML):
                     game_info = '%s [CR] Duration: %s' % (game['phase'], str(timedelta(seconds=int(float(game['video']['videoDuration'])))))
                 else:
                     game_info = game['phase']
+                    if game_info == 'FINAL_OVERTIME':
+                        game_info = 'FINAL'
             else:
                 if addon.getSetting('time_notation') == '0':  # 12-hour clock
                     datetime_format = '%A, %b %d - %I:%M %p'

--- a/default.py
+++ b/default.py
@@ -170,7 +170,7 @@ class GamepassGUI(xbmcgui.WindowXML):
                     game_info = '%s [CR] Duration: %s' % (game['phase'], str(timedelta(seconds=int(float(game['video']['videoDuration'])))))
                 else:
                     game_info = game['phase']
-                    if game_info == 'FINAL_OVERTIME':
+                    if addon.getSetting('hide_game_length') == 'true' and game_info == 'FINAL_OVERTIME':
                         game_info = 'FINAL'
             else:
                 if addon.getSetting('time_notation') == '0':  # 12-hour clock


### PR DESCRIPTION
As reported in #357 since a couple of weeks the game info (when hiding game length) tells you whether or not a game went into overtime. Undesirable when you chose such spoilers.

This PR simply checks for `FINAL_OVERTIME` and resets it to `FINAL` if found, making all games present themselves as `FINAL`.

_Code review remark:_ I could've gone with an if-else but this looked a lot cleaner, you immediately see what the code is doing here, only triggering when `FINAL_OVERTIME` is actually found.
