### PR TITLE
Force utf-8 encoding on game_info to prevent encoding issues for live games

### DIFF
--- a/default.py
+++ b/default.py
@@ -177,7 +177,7 @@ class GamepassGUI(xbmcgui.WindowXML):
                     datetime_format = '%A, %b %d - %H:%M'
 
                 datetime_obj = gp.parse_datetime(game['gameDateTimeUtc'], True)
-                game_info = datetime_obj.strftime(datetime_format)
+                game_info = datetime_obj.strftime(datetime_format).encode('utf-8')
 
             if game['videoStatus'] == 'SCHEDULED':
                 isPlayable = 'false'


### PR DESCRIPTION
When creating the game info text for live games, it's possible Python will throw an `UnicodeDecodeError` if the special marking `'[CR]» Live «'` is added to game_info. I think this is because `strftime()` using the systems default encoding, which could still be ascii. 

This commit forces it to be utf-8 which is better to use in Kodi+Python, as per the information found at https://forum.kodi.tv/showthread.php?tid=144677

This fixes issue #369 