### PR TITLE
Force live video game info to be interpreted as UTF-8

### DIFF
--- a/default.py
+++ b/default.py
@@ -203,7 +203,7 @@ class GamepassGUI(xbmcgui.WindowXML):
                 isPlayable = 'false'
                 isBlackedOut = 'false'
             elif game['videoStatus'] == 'LIVE':
-                game_info += '[CR]» Live «'
+                game_info += u'[CR]» Live «'
                 video_id = str(game['video']['videoId'])
                 isPlayable = 'true'
                 isBlackedOut = 'false'


### PR DESCRIPTION
The fix proposed in aqw/xbmc-gamepass#370 helped, but I still observed
some UnicodeDecodeError exceptions, when live games were on (as reported
in aqw/xbmc-gamepass#369).

Enforcing the Live tag string, which is added to game_info, to be
interpreted as UTF-8 got rid of all crashes during live games